### PR TITLE
Resize p5js canvas to content width

### DIFF
--- a/layouts/shortcodes/p5js.html
+++ b/layouts/shortcodes/p5js.html
@@ -9,7 +9,6 @@
 	<div class="p5js-canvas" id="p5js-{{$id}}-canvas"></div>
 	<script style="display: none;">
 	function sketch{{$id|safeJS}}(p) {
-		console.log('running sketch {{$id}}');
 		with (p) {
 			eval({{.Inner}});
 			{{$ids := slice "setup" "draw" "preload" "mousePressed" "mouseReleased" "mouseClicked" "mouseMoved" "mouseDragged" "mouseOver" "mouseOut" "keyPressed" "keyTyped" "keyReleased"}}
@@ -22,3 +21,15 @@
 	new p5(sketch{{$id|safeJS}}, 'p5js-{{$id}}-canvas');
 	</script>
 </div>
+
+<style>
+/* resize width */
+#p5js-{{$id}} canvas {
+  width: 100% !important;
+  height: auto !important;
+  min-width: 500px;
+}
+#body {
+  overflow-x: auto;
+}
+</style>


### PR DESCRIPTION
Alternate implementation of #9 , this also resizes the canvas content as well (in addition to, like #9, preserving aspect ratio). The `min-width` can be tweaked/removed as desired. 